### PR TITLE
[WIP][update] Support for third party confirmation of post-auth state using PIN

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1147,14 +1147,13 @@ int _main(uint32_t task_id)
                 /* Reboot request */
             case MAGIC_REBOOT_REQUEST:
                 {
-                    if (sinker == id_usb) {
-                        ret =
-                            sys_ipc(IPC_SEND_SYNC, id_smart,
-                                    sizeof(t_ipc_command),
-                                    (const char *) &ipc_mainloop_cmd);
-                        if(ret != SYS_E_DONE) {
-                           goto err;
-                        }
+                    /* anyone can requst reboot event on error */
+                    ret =
+                        sys_ipc(IPC_SEND_SYNC, id_smart,
+                                sizeof(t_ipc_command),
+                                (const char *) &ipc_mainloop_cmd);
+                    if(ret != SYS_E_DONE) {
+                        goto err;
                     }
                     break;
                 }

--- a/src/main.c
+++ b/src/main.c
@@ -199,6 +199,24 @@ static int cbc_essiv_iv_derivation(uint32_t sector_number, uint8_t * iv,
 }
 
 
+/* Ask the dfusmart task to reboot through IPC */
+static void ask_reboot(void){
+        struct sync_command_data sync_command;
+        sync_command.magic = MAGIC_REBOOT_REQUEST;
+        sync_command.state = SYNC_WAIT;
+        sys_ipc(IPC_SEND_SYNC, id_smart,
+                    sizeof(struct sync_command),
+                    (char*)&sync_command);
+	/* We should not end up here in case of reset ...
+	 * But this can happen when dfusmart refuses to perform
+	 * the reset: in this case, we yield.
+	 */
+        while (1) {
+        	sys_yield();
+        }
+}
+
+
 
 /*
  * We use the local -fno-stack-protector flag for main because
@@ -1177,6 +1195,7 @@ err_init:
     }
 err:
     /* to be replaced by reset request IPC */
+    ask_reboot();
     while (1) {
         sys_yield();
     }


### PR DESCRIPTION
## trusted third party for DFU

crypto is requesting PIN to confirm the post-authentication state in order to limit the impact of smart corruption in nominal mode.
In case of smart corruption, the user should be able to detect an invalid token through its passphrase verification hold by PIN itself